### PR TITLE
hotfix: Remove Jupiter notebook from used langs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
   <a href="https://github.com/MichaelBittencourt">
   <img height="180em" src="https://github-readme-stats.vercel.app/api?username=MichaelBittencourt&show_icons=true&theme=algolia&include_all_commits=true&count_private=true"/>
-  <img height="180em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=MichaelBittencourt&layout=compact&langs_count=10&theme=algolia"/>
+  <img height="180em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=MichaelBittencourt&hide=jupyter%20notebook&layout=compact&langs_count=10&theme=algolia"/>
 </div>
 
 <div style="display: inline_block"><br>


### PR DESCRIPTION
On the list of used langs the Jupiter notebook as shown as the most used language, but it occurs because the projects that use jupiter notebook has a large amount of code.